### PR TITLE
Updated GYRO_SENSITIVITY_XXXDPS setting per NXP datasheet

### DIFF
--- a/Adafruit_FXAS21002C.h
+++ b/Adafruit_FXAS21002C.h
@@ -29,12 +29,12 @@
 /*=========================================================================
     I2C ADDRESS/BITS AND SETTINGS
     -----------------------------------------------------------------------*/
-    #define FXAS21002C_ADDRESS       (0x21)        // 0100001
-    #define FXAS21002C_ID            (0xD7)        // 1101 0111
-    #define GYRO_SENSITIVITY_250DPS  (0.00875F)    // Roughly 22/256 for fixed point match
-    #define GYRO_SENSITIVITY_500DPS  (0.0175F)     // Roughly 45/256
-    #define GYRO_SENSITIVITY_1000DPS (0.035F)      // Roughly 9/256
-    #define GYRO_SENSITIVITY_2000DPS (0.070F)      // Roughly 18/256
+    #define FXAS21002C_ADDRESS       (0x21)       // 0100001
+    #define FXAS21002C_ID            (0xD7)       // 1101 0111
+    #define GYRO_SENSITIVITY_250DPS  (0.0625F)    // Page 9 of NXP datasheet FXAS21002C
+    #define GYRO_SENSITIVITY_500DPS  (0.03125F)   // ..
+    #define GYRO_SENSITIVITY_1000DPS (0.015625F)  // ..
+    #define GYRO_SENSITIVITY_2000DPS (0.0078125F) // ..
 /*=========================================================================*/
 
 /*=========================================================================


### PR DESCRIPTION
I may be wrong but I think the GYRO_SENSITIVITY_XXXDPS settings in the header file needed to be corrected per the NXP datasheet.