### PR TITLE
Add configurable I2C address

### DIFF
--- a/Adafruit_FXAS21002C.cpp
+++ b/Adafruit_FXAS21002C.cpp
@@ -55,7 +55,7 @@
 */
 /**************************************************************************/
 void Adafruit_FXAS21002C::write8(byte reg, byte value) {
-  Wire.beginTransmission(FXAS21002C_ADDRESS);
+  Wire.beginTransmission(_sensorAddr);
 #if ARDUINO >= 100
   Wire.write((uint8_t)reg);
   Wire.write((uint8_t)value);
@@ -76,7 +76,7 @@ void Adafruit_FXAS21002C::write8(byte reg, byte value) {
 byte Adafruit_FXAS21002C::read8(byte reg) {
   byte value;
 
-  Wire.beginTransmission((byte)FXAS21002C_ADDRESS);
+  Wire.beginTransmission((byte)_sensorAddr);
 #if ARDUINO >= 100
   Wire.write((uint8_t)reg);
 #else
@@ -84,7 +84,7 @@ byte Adafruit_FXAS21002C::read8(byte reg) {
 #endif
   if (Wire.endTransmission(false) != 0)
     return 0;
-  Wire.requestFrom((byte)FXAS21002C_ADDRESS, (byte)1);
+  Wire.requestFrom((byte)_sensorAddr, (byte)1);
 #if ARDUINO >= 100
   value = Wire.read();
 #else
@@ -104,10 +104,12 @@ byte Adafruit_FXAS21002C::read8(byte reg) {
             a unique ID to the gyroscope for logging purposes.
 
     @param sensorID The unique ID to associate with the gyroscope.
+    @param addr The I2C address of the sensor.
 */
 /**************************************************************************/
-Adafruit_FXAS21002C::Adafruit_FXAS21002C(int32_t sensorID) {
+Adafruit_FXAS21002C::Adafruit_FXAS21002C(int32_t sensorID, byte addr) {
   _sensorID = sensorID;
+  _sensorAddr = addr;
 }
 
 /***************************************************************************
@@ -233,14 +235,14 @@ bool Adafruit_FXAS21002C::getEvent(sensors_event_t *event) {
   event->timestamp = millis();
 
   /* Read 7 bytes from the sensor */
-  Wire.beginTransmission((byte)FXAS21002C_ADDRESS);
+  Wire.beginTransmission((byte)_sensorAddr);
 #if ARDUINO >= 100
   Wire.write(GYRO_REGISTER_STATUS | 0x80);
 #else
   Wire.send(GYRO_REGISTER_STATUS | 0x80);
 #endif
   Wire.endTransmission();
-  Wire.requestFrom((byte)FXAS21002C_ADDRESS, (byte)7);
+  Wire.requestFrom((byte)_sensorAddr, (byte)7);
 
 #if ARDUINO >= 100
   uint8_t status = Wire.read();

--- a/Adafruit_FXAS21002C.h
+++ b/Adafruit_FXAS21002C.h
@@ -33,7 +33,7 @@
     I2C ADDRESS/BITS AND SETTINGS
     -----------------------------------------------------------------------*/
 /** 7-bit address for this sensor */
-#define FXAS21002C_ADDRESS (0x21) // 0100001
+// #define FXAS21002C_ADDRESS (0x21) // 0100001
 /** Device ID for this sensor (used as a sanity check during init) */
 #define FXAS21002C_ID (0xD7) // 1101 0111
 /** Gyroscope sensitivity at 250dps */
@@ -105,7 +105,7 @@ typedef struct gyroRawData_s {
 /**************************************************************************/
 class Adafruit_FXAS21002C : public Adafruit_Sensor {
 public:
-  Adafruit_FXAS21002C(int32_t sensorID = -1);
+  Adafruit_FXAS21002C(int32_t sensorID = -1, byte addr = 0x21);
 
   bool begin(gyroRange_t rng = GYRO_RANGE_250DPS);
   bool getEvent(sensors_event_t *event);
@@ -120,6 +120,7 @@ private:
   byte read8(byte reg);
   gyroRange_t _range;
   int32_t _sensorID;
+  byte _sensorAddr;
 };
 
 #endif

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit FXAS21002C
-version=1.3.0
+version=1.4.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Unified sensor driver for the FXAS210002C Gyroscope


### PR DESCRIPTION
This allows the class to work on other addresses configured with the SA0/1 pins on the FXAS21002C. It still defaults to the current address as configured by Adafruit's 9-axis board, and was implemented such that any code currently working with this class will still function as-is. 

This configuration option on other Sensor libraries is implemented as part of the `begin()` method. However, implementing it here would have possible breaking-change possibilities given there's already a configuration option in this method. I am open to thoughts on placing it here to be more standardized.

I have tested with the Freescale Freedom board with these devices on it with a Grand Central M4, because those are the boards I have, but the logical structure is all still the same so shouldn't impact the operation previously.