### PR TITLE
Move to BusIO

### DIFF
--- a/Adafruit_FXAS21002C.cpp
+++ b/Adafruit_FXAS21002C.cpp
@@ -218,12 +218,12 @@ void Adafruit_FXAS21002C::getSensor(sensor_t *sensor) {
 /**************************************************************************/
 void Adafruit_FXAS21002C::standby(boolean standby) {
   Adafruit_BusIO_Register CTRL_REG1(i2c_dev, GYRO_REGISTER_CTRL_REG1);
-  Adafruit_BusIO_RegisterBits active_bit(&CTRL_REG1, 1, 1);
+  Adafruit_BusIO_RegisterBits active_bit(&CTRL_REG1, 1, 2);
 
   if (standby) {
-    active_bit.write(0);
+    active_bit.write(0x00);
     delay(100);
   } else {
-    active_bit.write(1);
+    active_bit.write(0x03);
   }
 }

--- a/Adafruit_FXAS21002C.h
+++ b/Adafruit_FXAS21002C.h
@@ -20,13 +20,10 @@
 #ifndef __FXAS21002C_H__
 #define __FXAS21002C_H__
 
-#if (ARDUINO >= 100)
-#include "Arduino.h"
-#else
-#include "WProgram.h"
-#endif
-
+#include <Adafruit_BusIO_Register.h>
+#include <Adafruit_I2CDevice.h>
 #include <Adafruit_Sensor.h>
+#include <Arduino.h>
 #include <Wire.h>
 
 /*=========================================================================
@@ -105,9 +102,8 @@ typedef struct gyroRawData_s {
 /**************************************************************************/
 class Adafruit_FXAS21002C : public Adafruit_Sensor {
 public:
-  Adafruit_FXAS21002C(int32_t sensorID = -1, byte addr = 0x21);
-
-  bool begin(gyroRange_t rng = GYRO_RANGE_250DPS);
+  Adafruit_FXAS21002C(int32_t sensorID = -1);
+  bool begin(uint8_t addr = 0x21, TwoWire *wire = &Wire);
   bool getEvent(sensors_event_t *event);
   void getSensor(sensor_t *sensor);
   void standby(boolean standby);
@@ -115,12 +111,13 @@ public:
   /*! Raw gyroscope values from last sensor read */
   gyroRawData_t raw;
 
+protected:
+  Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
+
 private:
-  void write8(byte reg, byte value);
-  byte read8(byte reg);
+  bool initialize();
   gyroRange_t _range;
   int32_t _sensorID;
-  byte _sensorAddr;
 };
 
 #endif

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit FXAS21002C
-version=1.4.0
+version=2.0.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Unified sensor driver for the FXAS210002C Gyroscope
@@ -7,4 +7,4 @@ paragraph=Unified sensor driver for the FXAS21002C Gyroscope
 category=Sensors
 url=https://github.com/adafruit/Adafruit_FXAS21002C
 architectures=*
-depends=Adafruit Unified Sensor
+depends=Adafruit Unified Sensor, Adafruit BusIO


### PR DESCRIPTION
This is for #10.

**BREAKING**
The ctors and begin() calls have been changed slightly to be more in line with other libraries. addr has been moved to begin() and the parameter to set gyro range has been removed. Example still works as expected:
![Screenshot from 2021-06-23 10-50-19](https://user-images.githubusercontent.com/8755041/123145156-63460d80-d411-11eb-8a92-28a4ca134f50.png)
