### PR TITLE
Fix bits for standby

### DIFF
--- a/Adafruit_FXAS21002C.cpp
+++ b/Adafruit_FXAS21002C.cpp
@@ -218,7 +218,7 @@ void Adafruit_FXAS21002C::getSensor(sensor_t *sensor) {
 /**************************************************************************/
 void Adafruit_FXAS21002C::standby(boolean standby) {
   Adafruit_BusIO_Register CTRL_REG1(i2c_dev, GYRO_REGISTER_CTRL_REG1);
-  Adafruit_BusIO_RegisterBits active_bit(&CTRL_REG1, 1, 2);
+  Adafruit_BusIO_RegisterBits active_bit(&CTRL_REG1, 2, 0);
 
   if (standby) {
     active_bit.write(0x00);


### PR DESCRIPTION
I think I did this wrong. Got the shift / width parameters mixed up. Want to set the bottom two bits to either all 0's or all 1's. So `bits=2` and `shift=0`.

![image](https://user-images.githubusercontent.com/8755041/123558104-7c202d00-d749-11eb-8591-b13dda008a8f.png)

Although the lower (READY) bit looks moot when to upper (ACTIVE) bit is set. 
![image](https://user-images.githubusercontent.com/8755041/123558143-b8538d80-d749-11eb-953c-019e5cf44540.png)

