### PR TITLE
Add back gyro range

### DIFF
--- a/Adafruit_FXAS21002C.cpp
+++ b/Adafruit_FXAS21002C.cpp
@@ -212,6 +212,31 @@ void Adafruit_FXAS21002C::getSensor(sensor_t *sensor) {
 
 /**************************************************************************/
 /*!
+    @brief  Set the gyroscope full scale range.
+    @param  range gyroscope full scane range
+*/
+/**************************************************************************/
+void Adafruit_FXAS21002C::setRange(gyroRange_t range) {
+  Adafruit_BusIO_Register CTRL_REG0(i2c_dev, GYRO_REGISTER_CTRL_REG0);
+  Adafruit_BusIO_RegisterBits range_bits(&CTRL_REG0, 2, 0);
+
+  standby(true);
+  range_bits.write(range);
+  standby(false);
+
+  _range = range;
+}
+
+/**************************************************************************/
+/*!
+    @brief  Get the gyroscope full scale range.
+    @return  gyroscope full scane range
+*/
+/**************************************************************************/
+gyroRange_t Adafruit_FXAS21002C::getRange() { return _range; }
+
+/**************************************************************************/
+/*!
     @brief  Puts devince into/out of standby mode
     @param  standby Whether we want to go into standby!
 */

--- a/Adafruit_FXAS21002C.h
+++ b/Adafruit_FXAS21002C.h
@@ -108,8 +108,9 @@ public:
   void getSensor(sensor_t *sensor);
   void standby(boolean standby);
 
-  /*! Raw gyroscope values from last sensor read */
-  gyroRawData_t raw;
+  void setRange(gyroRange_t range);
+  gyroRange_t getRange();
+  gyroRawData_t raw; ///< Raw gyroscope values from last sensor read
 
 protected:
   Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface

--- a/examples/sensorapi/sensorapi.ino
+++ b/examples/sensorapi/sensorapi.ino
@@ -49,6 +49,9 @@ void setup(void) {
       ;
   }
 
+  /* Set gyro range. (optional, default is 250 dps) */
+  // gyro.setRange(GYRO_RANGE_2000DPS);
+
   /* Display some basic information on this sensor */
   displaySensorDetails();
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit FXAS21002C
-version=2.0.1
+version=2.1.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Unified sensor driver for the FXAS210002C Gyroscope


### PR DESCRIPTION
For #13.

Previously, gyro range was passed in as a parameter to `begin()`. This was removed as part of #11. This PR adds back the ability to get/set the gyro range via new getter/setter funcs.

For ref:
![image](https://user-images.githubusercontent.com/8755041/128383922-b476ab16-2452-42fe-9b42-a3c0546cc147.png)

Example update with commented out example usage.

Tested with example on Qt PY:
![Screenshot from 2021-08-05 08-33-37](https://user-images.githubusercontent.com/8755041/128378998-309ccf7f-b0ef-4d9c-be05-cf51fe2ff599.png)
