### PR TITLE
Tweak memory alloc and cleanup

### DIFF
--- a/Adafruit_FXAS21002C.cpp
+++ b/Adafruit_FXAS21002C.cpp
@@ -85,6 +85,15 @@ Adafruit_FXAS21002C::Adafruit_FXAS21002C(int32_t sensorID) {
 }
 
 /***************************************************************************
+ DESTRUCTOR
+ ***************************************************************************/
+
+Adafruit_FXAS21002C::~Adafruit_FXAS21002C() {
+  if (i2c_dev)
+    delete i2c_dev;
+}
+
+/***************************************************************************
  PUBLIC FUNCTIONS
  ***************************************************************************/
 
@@ -100,6 +109,8 @@ Adafruit_FXAS21002C::Adafruit_FXAS21002C(int32_t sensorID) {
 /**************************************************************************/
 bool Adafruit_FXAS21002C::begin(uint8_t addr, TwoWire *wire) {
 
+  if (i2c_dev)
+    delete i2c_dev;
   i2c_dev = new Adafruit_I2CDevice(addr, wire);
   if (!i2c_dev->begin())
     return false;

--- a/Adafruit_FXAS21002C.h
+++ b/Adafruit_FXAS21002C.h
@@ -103,6 +103,7 @@ typedef struct gyroRawData_s {
 class Adafruit_FXAS21002C : public Adafruit_Sensor {
 public:
   Adafruit_FXAS21002C(int32_t sensorID = -1);
+  ~Adafruit_FXAS21002C();
   bool begin(uint8_t addr = 0x21, TwoWire *wire = &Wire);
   bool getEvent(sensors_event_t *event);
   void getSensor(sensor_t *sensor);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit FXAS21002C
-version=2.1.0
+version=2.1.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Unified sensor driver for the FXAS210002C Gyroscope


### PR DESCRIPTION
Tested with Qt PY:
```cpp
#include <Adafruit_FXAS21002C.h>

Adafruit_FXAS21002C gyro = Adafruit_FXAS21002C(0x0021002C);

void setup(void) {
  Serial.begin(9600);
  while (!Serial) delay(1);

  Serial.println("Gyroscope Test");
  Serial.println("");
}

void loop(void) {
  if (!gyro.begin()) {
    Serial.println("Ooops, no FXAS21002C detected ... Check your wiring!");
    while (1) ;
  }
  
  /* Get a new sensor event */
  sensors_event_t event;
  gyro.getEvent(&event);

  /* Display the results (speed is measured in rad/s) */
  Serial.print("X: ");
  Serial.print(event.gyro.x);
  Serial.print("  ");
  Serial.print("Y: ");
  Serial.print(event.gyro.y);
  Serial.print("  ");
  Serial.print("Z: ");
  Serial.print(event.gyro.z);
  Serial.print("  ");
  Serial.println("rad/s ");
 
  delay(1000);
}
```

![Screenshot from 2021-08-24 11-09-51](https://user-images.githubusercontent.com/8755041/130669091-0d57e59e-f767-4ef2-a801-6224aaea8382.png)
