### PR TITLE
fixed incorrect full range selection after the initialization and added set/get output data rate

### DIFF
--- a/Adafruit_FXAS21002C.cpp
+++ b/Adafruit_FXAS21002C.cpp
@@ -61,7 +61,7 @@ bool Adafruit_FXAS21002C::initialize() {
   /* Reset then switch to active mode with 100Hz output */
   CTRL_REG1.write(0x00);   // Standby
   CTRL_REG1.write(1 << 6); // Reset
-  CTRL_REG0.write(0x03);   // Set sensitivity
+  CTRL_REG0.write(0x03);   // Set sensitivity which corresponds to the range of +-250 dps
   CTRL_REG1.write(0x0E);   // Active
   delay(100);              // 60ms + 1/ODR
 
@@ -232,7 +232,24 @@ void Adafruit_FXAS21002C::setRange(gyroRange_t range) {
   Adafruit_BusIO_RegisterBits range_bits(&CTRL_REG0, 2, 0);
 
   standby(true);
-  range_bits.write(range);
+
+  // write FS[1:0] bits (bits controlling the full scale range) with correct values according to page 40 of the datasheet
+  switch( range )
+  {
+    case GYRO_RANGE_250DPS:
+      range_bits.write(0b11);
+      break;
+    case GYRO_RANGE_500DPS:
+      range_bits.write(0b10);
+      break;
+    case GYRO_RANGE_1000DPS:
+      range_bits.write(0b01);
+      break;
+    case GYRO_RANGE_2000DPS:
+      range_bits.write(0b00);
+      break;
+  }
+
   standby(false);
 
   _range = range;

--- a/Adafruit_FXAS21002C.cpp
+++ b/Adafruit_FXAS21002C.cpp
@@ -61,10 +61,9 @@ bool Adafruit_FXAS21002C::initialize() {
   /* Reset then switch to active mode with 100Hz output */
   CTRL_REG1.write(0x00);   // Standby
   CTRL_REG1.write(1 << 6); // Reset
-  CTRL_REG0.write(
-      0x03); // Set sensitivity which corresponds to the range of +-250 dps
-  CTRL_REG1.write(0x0E); // Active
-  delay(100);            // 60ms + 1/ODR
+  CTRL_REG0.write(0x03);   // Set full scale range to +-250 dps
+  CTRL_REG1.write(0x0E);   // Active
+  delay(100);              // 60ms + 1/ODR
 
   return true;
 }

--- a/Adafruit_FXAS21002C.cpp
+++ b/Adafruit_FXAS21002C.cpp
@@ -353,3 +353,4 @@ gyroODR_t Adafruit_FXAS21002C::getODR() {
     break;
   }
 }
+

--- a/Adafruit_FXAS21002C.cpp
+++ b/Adafruit_FXAS21002C.cpp
@@ -61,9 +61,10 @@ bool Adafruit_FXAS21002C::initialize() {
   /* Reset then switch to active mode with 100Hz output */
   CTRL_REG1.write(0x00);   // Standby
   CTRL_REG1.write(1 << 6); // Reset
-  CTRL_REG0.write(0x03);   // Set sensitivity which corresponds to the range of +-250 dps
-  CTRL_REG1.write(0x0E);   // Active
-  delay(100);              // 60ms + 1/ODR
+  CTRL_REG0.write(
+      0x03); // Set sensitivity which corresponds to the range of +-250 dps
+  CTRL_REG1.write(0x0E); // Active
+  delay(100);            // 60ms + 1/ODR
 
   return true;
 }
@@ -233,21 +234,21 @@ void Adafruit_FXAS21002C::setRange(gyroRange_t range) {
 
   standby(true);
 
-  // write FS[1:0] bits (bits controlling the full scale range) with correct values according to page 40 of the datasheet
-  switch( range )
-  {
-    case GYRO_RANGE_250DPS:
-      range_bits.write(0b11);
-      break;
-    case GYRO_RANGE_500DPS:
-      range_bits.write(0b10);
-      break;
-    case GYRO_RANGE_1000DPS:
-      range_bits.write(0b01);
-      break;
-    case GYRO_RANGE_2000DPS:
-      range_bits.write(0b00);
-      break;
+  /* write FS[1:0] bits (bits controlling the full scale range) with correct
+   * values according to page 40 of the datasheet */
+  switch (range) {
+  case GYRO_RANGE_250DPS:
+    range_bits.write(0b11);
+    break;
+  case GYRO_RANGE_500DPS:
+    range_bits.write(0b10);
+    break;
+  case GYRO_RANGE_1000DPS:
+    range_bits.write(0b01);
+    break;
+  case GYRO_RANGE_2000DPS:
+    range_bits.write(0b00);
+    break;
   }
 
   standby(false);

--- a/Adafruit_FXAS21002C.cpp
+++ b/Adafruit_FXAS21002C.cpp
@@ -281,12 +281,11 @@ void Adafruit_FXAS21002C::standby(boolean standby) {
   }
 }
 
-
 /**************************************************************************/
 /*!
     @brief  Configures the device with certain output data rate(ODR)
             Currently supports ODRs: 8000Hz, 400Hz, 200Hz, 100Hz, 50Hz, 25Hz
-    @param   ODR : the output data rate to be set to the gyroscope!
+    @param   ODR : the output data rate to be set to the gyroscope
 */
 /**************************************************************************/
 void Adafruit_FXAS21002C::setODR(gyroODR_t ODR) {

--- a/Adafruit_FXAS21002C.cpp
+++ b/Adafruit_FXAS21002C.cpp
@@ -297,41 +297,37 @@ void Adafruit_FXAS21002C::setODR(float ODR) {
    * mode */
   standby(true);
 
-  switch (ODR) {
-  case GYRO_ODR_800HZ:
+  if(ODR == GYRO_ODR_800HZ) {
     datarate_bits.write(0b000);
     _ODR = ODR;
-    break;
-  case GYRO_ODR_400HZ:
+ }
+  else if(ODR == GYRO_ODR_400HZ) {
     datarate_bits.write(0b001);
     _ODR = ODR;
-    break;
-  case GYRO_ODR_200HZ:
+}
+  else if (ODR == GYRO_ODR_200HZ){
     datarate_bits.write(0b010);
     _ODR = ODR;
-    break;
-  case GYRO_ODR_100HZ:
-    datarate_bits.write(0b011);
+  }
+
+  else if(ODR == GYRO_ODR_100HZ){
+        datarate_bits.write(0b011);
     _ODR = ODR;
-    break;
-  case GYRO_ODR_50HZ:
-    datarate_bits.write(0b100);
+  }
+
+  else if(ODR == GYRO_ODR_50HZ){
+        datarate_bits.write(0b100);
     _ODR = ODR;
-    break;
-  case GYRO_ODR_25HZ:
-    datarate_bits.write(0b101);
+  }
+
+  else if(ODR == GYRO_ODR_25HZ){
+        datarate_bits.write(0b101);
     _ODR = ODR;
-    break;
-  case GYRO_ODR_12_5HZ:
+  }
+
+  else if (ODR == GYRO_ODR_12_5HZ){
     datarate_bits.write(0b110);
     _ODR = ODR;
-    break;
-  /*
-  The default case only occurs when the ODR does not fall into any of the valid
-  ODRs The invalid ODR will be ignored
-  */
-  default:
-    break;
   }
 
   standby(false);

--- a/Adafruit_FXAS21002C.cpp
+++ b/Adafruit_FXAS21002C.cpp
@@ -62,8 +62,8 @@ bool Adafruit_FXAS21002C::initialize() {
   CTRL_REG1.write(0x00);   // Standby
   CTRL_REG1.write(1 << 6); // Reset
   CTRL_REG0.write(0x03);   // Set full scale range to +-250 dps
-  CTRL_REG1.write(0x0E);   // Active
   _ODR = GYRO_ODR_100HZ;   // Update global ODR variable
+  CTRL_REG1.write(0x0E);   // Active
   delay(100);              // 60ms + 1/ODR
 
   return true;
@@ -285,11 +285,11 @@ void Adafruit_FXAS21002C::standby(boolean standby) {
 /**************************************************************************/
 /*!
     @brief  Configures the device with certain output data rate(ODR)
-            Currently supports ODRs: 8000Hz, 400Hz, 200Hz, 100Hz, 50Hz, 25Hz
+            Supports ODRs: 8000Hz, 400Hz, 200Hz, 100Hz, 50Hz, 25Hz, 12.5Hz
     @param   ODR : the output data rate to be set to the gyroscope
 */
 /**************************************************************************/
-void Adafruit_FXAS21002C::setODR(gyroODR_t ODR) {
+void Adafruit_FXAS21002C::setODR(float ODR) {
   Adafruit_BusIO_Register CTRL_REG1(i2c_dev, GYRO_REGISTER_CTRL_REG1);
   Adafruit_BusIO_RegisterBits datarate_bits(&CTRL_REG1, 3, 2);
 
@@ -300,23 +300,40 @@ void Adafruit_FXAS21002C::setODR(gyroODR_t ODR) {
   switch (ODR) {
   case GYRO_ODR_800HZ:
     datarate_bits.write(0b000);
+    _ODR = ODR;
     break;
   case GYRO_ODR_400HZ:
     datarate_bits.write(0b001);
+    _ODR = ODR;
     break;
   case GYRO_ODR_200HZ:
     datarate_bits.write(0b010);
+    _ODR = ODR;
     break;
   case GYRO_ODR_100HZ:
     datarate_bits.write(0b011);
+    _ODR = ODR;
     break;
   case GYRO_ODR_50HZ:
     datarate_bits.write(0b100);
+    _ODR = ODR;
     break;
   case GYRO_ODR_25HZ:
     datarate_bits.write(0b101);
+    _ODR = ODR;
+    break;
+  case GYRO_ODR_12_5HZ:
+    datarate_bits.write(0b110);
+    _ODR = ODR;
+    break;
+  /*
+  The default case only occurs when the ODR does not fall into any of the valid
+  ODRs The invalid ODR will be ignored
+  */
+  default:
     break;
   }
+
   standby(false);
 }
 
@@ -327,7 +344,7 @@ void Adafruit_FXAS21002C::setODR(gyroODR_t ODR) {
     @return The Output Data Rate(ODR) in Hz
 */
 /**************************************************************************/
-gyroODR_t Adafruit_FXAS21002C::getODR() {
+float Adafruit_FXAS21002C::getODR() {
   Adafruit_BusIO_Register CTRL_REG1(i2c_dev, GYRO_REGISTER_CTRL_REG1);
   Adafruit_BusIO_RegisterBits datarate_bits(&CTRL_REG1, 3, 2);
 
@@ -336,30 +353,31 @@ gyroODR_t Adafruit_FXAS21002C::getODR() {
   switch (datarate_bits.read()) {
   case 0b000:
     _ODR = GYRO_ODR_800HZ;
-    return GYRO_ODR_800HZ;
     break;
   case 0b001:
     _ODR = GYRO_ODR_400HZ;
-    return GYRO_ODR_400HZ;
     break;
   case 0b010:
     _ODR = GYRO_ODR_200HZ;
-    return GYRO_ODR_200HZ;
     break;
   case 0b011:
     _ODR = GYRO_ODR_100HZ;
-    return GYRO_ODR_100HZ;
     break;
   case 0b100:
     _ODR = GYRO_ODR_50HZ;
-    return GYRO_ODR_50HZ;
     break;
   case 0b101:
     _ODR = GYRO_ODR_25HZ;
-    return GYRO_ODR_25HZ;
     break;
+  case 0b110:
+    _ODR = GYRO_ODR_12_5HZ;
+    break;
+  case 0b111:
+    _ODR = GYRO_ODR_12_5HZ;
+  /* The default case will never occur. It is here to accommodate different
+   * compilers */
   default:
-    return _ODR;
     break;
   }
+  return _ODR;
 }

--- a/Adafruit_FXAS21002C.cpp
+++ b/Adafruit_FXAS21002C.cpp
@@ -63,6 +63,7 @@ bool Adafruit_FXAS21002C::initialize() {
   CTRL_REG1.write(1 << 6); // Reset
   CTRL_REG0.write(0x03);   // Set full scale range to +-250 dps
   CTRL_REG1.write(0x0E);   // Active
+  _ODR = GYRO_ODR_100HZ;   // Update global ODR variable
   delay(100);              // 60ms + 1/ODR
 
   return true;
@@ -334,23 +335,31 @@ gyroODR_t Adafruit_FXAS21002C::getODR() {
    * corresponding ODR in Hz */
   switch (datarate_bits.read()) {
   case 0b000:
+    _ODR = GYRO_ODR_800HZ;
     return GYRO_ODR_800HZ;
     break;
   case 0b001:
+    _ODR = GYRO_ODR_400HZ;
     return GYRO_ODR_400HZ;
     break;
   case 0b010:
+    _ODR = GYRO_ODR_200HZ;
     return GYRO_ODR_200HZ;
     break;
   case 0b011:
+    _ODR = GYRO_ODR_100HZ;
     return GYRO_ODR_100HZ;
     break;
   case 0b100:
+    _ODR = GYRO_ODR_50HZ;
     return GYRO_ODR_50HZ;
     break;
   case 0b101:
+    _ODR = GYRO_ODR_25HZ;
     return GYRO_ODR_25HZ;
+    break;
+  default:
+    return _ODR;
     break;
   }
 }
-

--- a/Adafruit_FXAS21002C.cpp
+++ b/Adafruit_FXAS21002C.cpp
@@ -280,3 +280,77 @@ void Adafruit_FXAS21002C::standby(boolean standby) {
     active_bit.write(0x03);
   }
 }
+
+
+/**************************************************************************/
+/*!
+    @brief  Configures the device with certain output data rate(ODR)
+            Currently supports ODRs: 8000Hz, 400Hz, 200Hz, 100Hz, 50Hz, 25Hz
+    @param   ODR : the output data rate to be set to the gyroscope!
+*/
+/**************************************************************************/
+void Adafruit_FXAS21002C::setODR(gyroODR_t ODR) {
+  Adafruit_BusIO_Register CTRL_REG1(i2c_dev, GYRO_REGISTER_CTRL_REG1);
+  Adafruit_BusIO_RegisterBits datarate_bits(&CTRL_REG1, 3, 2);
+
+  /* CTRL_REG1 should only be set in Standby or Ready mode. First enter Standby
+   * mode */
+  standby(true);
+
+  switch (ODR) {
+  case GYRO_ODR_800HZ:
+    datarate_bits.write(0b000);
+    break;
+  case GYRO_ODR_400HZ:
+    datarate_bits.write(0b001);
+    break;
+  case GYRO_ODR_200HZ:
+    datarate_bits.write(0b010);
+    break;
+  case GYRO_ODR_100HZ:
+    datarate_bits.write(0b011);
+    break;
+  case GYRO_ODR_50HZ:
+    datarate_bits.write(0b100);
+    break;
+  case GYRO_ODR_25HZ:
+    datarate_bits.write(0b101);
+    break;
+  }
+  standby(false);
+}
+
+/**************************************************************************/
+/*!
+    @brief  Obtain the current output data rate(ODR) from the gyroscope's
+   register
+    @return The Output Data Rate(ODR) in Hz
+*/
+/**************************************************************************/
+gyroODR_t Adafruit_FXAS21002C::getODR() {
+  Adafruit_BusIO_Register CTRL_REG1(i2c_dev, GYRO_REGISTER_CTRL_REG1);
+  Adafruit_BusIO_RegisterBits datarate_bits(&CTRL_REG1, 3, 2);
+
+  /* Read the current value in the Output Data Rate(ODR) bits and return the
+   * corresponding ODR in Hz */
+  switch (datarate_bits.read()) {
+  case 0b000:
+    return GYRO_ODR_800HZ;
+    break;
+  case 0b001:
+    return GYRO_ODR_400HZ;
+    break;
+  case 0b010:
+    return GYRO_ODR_200HZ;
+    break;
+  case 0b011:
+    return GYRO_ODR_100HZ;
+    break;
+  case 0b100:
+    return GYRO_ODR_50HZ;
+    break;
+  case 0b101:
+    return GYRO_ODR_25HZ;
+    break;
+  }
+}

--- a/Adafruit_FXAS21002C.cpp
+++ b/Adafruit_FXAS21002C.cpp
@@ -297,35 +297,33 @@ void Adafruit_FXAS21002C::setODR(float ODR) {
    * mode */
   standby(true);
 
-  if(ODR == GYRO_ODR_800HZ) {
+  if (ODR == GYRO_ODR_800HZ) {
     datarate_bits.write(0b000);
     _ODR = ODR;
- }
-  else if(ODR == GYRO_ODR_400HZ) {
+  } else if (ODR == GYRO_ODR_400HZ) {
     datarate_bits.write(0b001);
     _ODR = ODR;
-}
-  else if (ODR == GYRO_ODR_200HZ){
+  } else if (ODR == GYRO_ODR_200HZ) {
     datarate_bits.write(0b010);
     _ODR = ODR;
   }
 
-  else if(ODR == GYRO_ODR_100HZ){
-        datarate_bits.write(0b011);
+  else if (ODR == GYRO_ODR_100HZ) {
+    datarate_bits.write(0b011);
     _ODR = ODR;
   }
 
-  else if(ODR == GYRO_ODR_50HZ){
-        datarate_bits.write(0b100);
+  else if (ODR == GYRO_ODR_50HZ) {
+    datarate_bits.write(0b100);
     _ODR = ODR;
   }
 
-  else if(ODR == GYRO_ODR_25HZ){
-        datarate_bits.write(0b101);
+  else if (ODR == GYRO_ODR_25HZ) {
+    datarate_bits.write(0b101);
     _ODR = ODR;
   }
 
-  else if (ODR == GYRO_ODR_12_5HZ){
+  else if (ODR == GYRO_ODR_12_5HZ) {
     datarate_bits.write(0b110);
     _ODR = ODR;
   }

--- a/Adafruit_FXAS21002C.cpp
+++ b/Adafruit_FXAS21002C.cpp
@@ -285,7 +285,8 @@ void Adafruit_FXAS21002C::standby(boolean standby) {
 /**************************************************************************/
 /*!
     @brief  Configures the device with certain output data rate(ODR)
-            Supports ODRs: 8000Hz, 400Hz, 200Hz, 100Hz, 50Hz, 25Hz, 12.5Hz
+            Supports ODRs: 800.0Hz, 400.0Hz, 200.0Hz,
+   100.0Hz, 50.0Hz, 25.0Hz, 12.5Hz
     @param   ODR : the output data rate to be set to the gyroscope
 */
 /**************************************************************************/
@@ -296,38 +297,25 @@ void Adafruit_FXAS21002C::setODR(float ODR) {
   /* CTRL_REG1 should only be set in Standby or Ready mode. First enter Standby
    * mode */
   standby(true);
-
+  /* _ODR is only updated if the input ODR is one of the valid ODRs */
   if (ODR == GYRO_ODR_800HZ) {
     datarate_bits.write(0b000);
-    _ODR = ODR;
   } else if (ODR == GYRO_ODR_400HZ) {
     datarate_bits.write(0b001);
-    _ODR = ODR;
   } else if (ODR == GYRO_ODR_200HZ) {
     datarate_bits.write(0b010);
-    _ODR = ODR;
-  }
-
-  else if (ODR == GYRO_ODR_100HZ) {
+  } else if (ODR == GYRO_ODR_100HZ) {
     datarate_bits.write(0b011);
-    _ODR = ODR;
-  }
-
-  else if (ODR == GYRO_ODR_50HZ) {
+  } else if (ODR == GYRO_ODR_50HZ) {
     datarate_bits.write(0b100);
-    _ODR = ODR;
-  }
-
-  else if (ODR == GYRO_ODR_25HZ) {
+  } else if (ODR == GYRO_ODR_25HZ) {
     datarate_bits.write(0b101);
-    _ODR = ODR;
-  }
-
-  else if (ODR == GYRO_ODR_12_5HZ) {
+  } else if (ODR == GYRO_ODR_12_5HZ) {
     datarate_bits.write(0b110);
-    _ODR = ODR;
   }
-
+  // update internal _ODR variable. Note that this update happens regardless of
+  // the validity of ODR
+  _ODR = ODR;
   standby(false);
 }
 
@@ -338,40 +326,4 @@ void Adafruit_FXAS21002C::setODR(float ODR) {
     @return The Output Data Rate(ODR) in Hz
 */
 /**************************************************************************/
-float Adafruit_FXAS21002C::getODR() {
-  Adafruit_BusIO_Register CTRL_REG1(i2c_dev, GYRO_REGISTER_CTRL_REG1);
-  Adafruit_BusIO_RegisterBits datarate_bits(&CTRL_REG1, 3, 2);
-
-  /* Read the current value in the Output Data Rate(ODR) bits and return the
-   * corresponding ODR in Hz */
-  switch (datarate_bits.read()) {
-  case 0b000:
-    _ODR = GYRO_ODR_800HZ;
-    break;
-  case 0b001:
-    _ODR = GYRO_ODR_400HZ;
-    break;
-  case 0b010:
-    _ODR = GYRO_ODR_200HZ;
-    break;
-  case 0b011:
-    _ODR = GYRO_ODR_100HZ;
-    break;
-  case 0b100:
-    _ODR = GYRO_ODR_50HZ;
-    break;
-  case 0b101:
-    _ODR = GYRO_ODR_25HZ;
-    break;
-  case 0b110:
-    _ODR = GYRO_ODR_12_5HZ;
-    break;
-  case 0b111:
-    _ODR = GYRO_ODR_12_5HZ;
-  /* The default case will never occur. It is here to accommodate different
-   * compilers */
-  default:
-    break;
-  }
-  return _ODR;
-}
+float Adafruit_FXAS21002C::getODR() { return _ODR; }

--- a/Adafruit_FXAS21002C.h
+++ b/Adafruit_FXAS21002C.h
@@ -83,6 +83,22 @@ typedef enum {
 /*=========================================================================*/
 
 /*=========================================================================
+    OPTIONAL OUTPUT DATA RATE SETTINGS
+    -----------------------------------------------------------------------*/
+/*!
+    Enum to define valid gyroscope output data rate values(ODR)
+*/
+typedef enum {
+  GYRO_ODR_800HZ = 800, /**< 800Hz */
+  GYRO_ODR_400HZ = 400, /**< 400Hz */
+  GYRO_ODR_200HZ = 200, /**< 200Hz */
+  GYRO_ODR_100HZ = 100, /**< 100Hz */
+  GYRO_ODR_50HZ = 50,   /**<  50Hz */
+  GYRO_ODR_25HZ = 25,   /**<  25Hz */
+} gyroODR_t;
+/*=========================================================================*/
+
+/*=========================================================================
     RAW GYROSCOPE DATA TYPE
     -----------------------------------------------------------------------*/
 /*!
@@ -110,7 +126,9 @@ public:
   void standby(boolean standby);
 
   void setRange(gyroRange_t range);
+  void setODR(gyroODR_t ODR);
   gyroRange_t getRange();
+  gyroODR_t getODR();
   gyroRawData_t raw; ///< Raw gyroscope values from last sensor read
 
 protected:

--- a/Adafruit_FXAS21002C.h
+++ b/Adafruit_FXAS21002C.h
@@ -137,6 +137,7 @@ protected:
 private:
   bool initialize();
   gyroRange_t _range;
+  gyroODR_t _ODR;
   int32_t _sensorID;
 };
 

--- a/Adafruit_FXAS21002C.h
+++ b/Adafruit_FXAS21002C.h
@@ -43,6 +43,17 @@
 #define GYRO_SENSITIVITY_2000DPS (0.0625F)
 /*=========================================================================*/
 
+/*!
+    Define valid gyroscope output data rate values(ODR)
+*/
+#define GYRO_ODR_800HZ (800.0f) /**< 800Hz */
+#define GYRO_ODR_400HZ (400.0f) /**< 400Hz */
+#define GYRO_ODR_200HZ (200.0f) /**< 200Hz */
+#define GYRO_ODR_100HZ (100.0f) /**< 100Hz */
+#define GYRO_ODR_50HZ (50.0f)   /**<  50Hz */
+#define GYRO_ODR_25HZ (25.0f)   /**<  25Hz */
+#define GYRO_ODR_12_5HZ (12.5f) /**< 12.5Hz*/
+
 /*=========================================================================
     REGISTERS
     -----------------------------------------------------------------------*/
@@ -83,22 +94,6 @@ typedef enum {
 /*=========================================================================*/
 
 /*=========================================================================
-    OPTIONAL OUTPUT DATA RATE SETTINGS
-    -----------------------------------------------------------------------*/
-/*!
-    Enum to define valid gyroscope output data rate values(ODR)
-*/
-typedef enum {
-  GYRO_ODR_800HZ = 800, /**< 800Hz */
-  GYRO_ODR_400HZ = 400, /**< 400Hz */
-  GYRO_ODR_200HZ = 200, /**< 200Hz */
-  GYRO_ODR_100HZ = 100, /**< 100Hz */
-  GYRO_ODR_50HZ = 50,   /**<  50Hz */
-  GYRO_ODR_25HZ = 25,   /**<  25Hz */
-} gyroODR_t;
-/*=========================================================================*/
-
-/*=========================================================================
     RAW GYROSCOPE DATA TYPE
     -----------------------------------------------------------------------*/
 /*!
@@ -126,9 +121,9 @@ public:
   void standby(boolean standby);
 
   void setRange(gyroRange_t range);
-  void setODR(gyroODR_t ODR);
+  void setODR(float ODR);
   gyroRange_t getRange();
-  gyroODR_t getODR();
+  float getODR();
   gyroRawData_t raw; ///< Raw gyroscope values from last sensor read
 
 protected:
@@ -137,7 +132,7 @@ protected:
 private:
   bool initialize();
   gyroRange_t _range;
-  gyroODR_t _ODR;
+  float _ODR;
   int32_t _sensorID;
 };
 


### PR DESCRIPTION
This pull request fixes the issue that the full range selection is wrong after the sensor initialization.

In the current version of the driver, when `Adafruit_FXAS21002C::setRange(gyroRange_t range)` is called, 
the 2 least significant bits of CTRL_REG0, which control the full range, are not set correctly. This can be seen in line 235 in the cpp file. 

The function parameter 'range' should not be directly written to the 2 LSbits in CTRL_REG0. Instead, the 2 LSbits should be set according to page 40 of the datasheet. https://www.nxp.com/docs/en/data-sheet/FXAS21002.pdf

- **Scope of the change**
The `Adafruit_FXAS21002C::setRange(gyroRange_t range)` is updated with a switch statement that sets the 2 LSbits in CTRL_REG0 with correct values depending on the value of 'range'.
